### PR TITLE
GitHub actions: Limit running CI on pushes to only 'main' branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,9 @@
 name: CI
 
 on:
-  push: {}
+  push:
+    branches:
+      - "main"
   pull_request: {}
   # Run daily to catch breakages in new Rust versions as well as new cargo
   # audit findings.


### PR DESCRIPTION
This should prevent double CI runs for new PRs