### PR TITLE
bubblewrap: Copy/extract seeds with stream

### DIFF
--- a/dev-init.sh
+++ b/dev-init.sh
@@ -2,14 +2,6 @@
 set -eu
 
 cd
-
-# Note: Used for bwrap only, not for Docker.
-if [ -f /dev/shm/seed.tar ]; then
-    echo "Unpacking seed tarball..."
-    pv -i 0.1 /dev/shm/seed.tar | tar --ignore-zero --extract
-    rm /dev/shm/seed.tar
-fi
-
 mkdir -p .dev-init bin opt tmp w
 
 if [ -f ./.profile ]; then

--- a/src/user.rs
+++ b/src/user.rs
@@ -134,7 +134,7 @@ impl User {
             return Ok(());
         }
 
-        println!("Copying seed tarball");
+        println!("Copying/extracting seed tarball");
         let mut source = Command::new("pv")
             .args(["-i", "0.1"])
             .args(seeds.iter().map(|s| s.as_host_raw()))


### PR DESCRIPTION
Before this would write the seed tarball out, then read it. This is a little nicer because it's (likely) faster, and it gets rid of some shell script.