### PR TITLE
Stop setting hostname

### DIFF
--- a/src/bubblewrap.rs
+++ b/src/bubblewrap.rs
@@ -199,12 +199,6 @@ impl Bubblewrap {
         command.arg("--unshare-pid");
         command.arg("--unshare-uts");
 
-        command.arg("--hostname");
-        match &self.program.hostname {
-            Some(hostname) => command.arg(format!("{}.{hostname}", name.as_hostname())),
-            None => command.arg(name.as_hostname()),
-        };
-
         command.args(["--symlink", "/usr/bin", "/bin"]);
         command.args(["--dev", "/dev"]);
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -221,11 +221,6 @@ impl Docker {
         command.arg("run");
         command.arg("--detach");
         command.args(["--env", &format!("CUBICLE={}", env_name.as_str())]);
-        command.arg("--hostname");
-        match &self.program.hostname {
-            Some(hostname) => command.arg(format!("{}.{hostname}", env_name.as_hostname())),
-            None => command.arg(env_name.as_hostname()),
-        };
         command.arg("--init");
         command.args(["--name", &container_name.encoded()]);
         command.arg("--rm");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ mod fs_util;
 use fs_util::{try_exists, DirSummary};
 
 mod os_util;
-use os_util::{get_hostname, host_home_dir};
+use os_util::host_home_dir;
 
 mod packages;
 use packages::write_package_list_tar;
@@ -94,7 +94,6 @@ struct CubicleShared {
     config: Config,
     shell: String,
     exe_name: String,
-    hostname: Option<String>,
     home: HostPath,
     user: String,
     package_cache: HostPath,
@@ -121,7 +120,6 @@ impl Cubicle {
     /// - Loading and initializing filesystem structures.
     /// - Creating a runner.
     pub fn new(config: Config) -> Result<Self> {
-        let hostname = get_hostname();
         let home = host_home_dir().clone();
         let user = std::env::var("USER").context("Invalid $USER")?;
         let shell = std::env::var("SHELL").unwrap_or_else(|_| String::from("/bin/sh"));
@@ -212,7 +210,6 @@ impl Cubicle {
             config,
             shell,
             exe_name,
-            hostname,
             home,
             user,
             package_cache,
@@ -564,21 +561,6 @@ impl EnvironmentName {
     /// Returns a string slice representing the environment name.
     pub fn as_str(&self) -> &str {
         &self.0
-    }
-
-    /// Returns a string representing the environment name for use in a domain
-    /// name.
-    fn as_hostname(&self) -> String {
-        self.0
-            .chars()
-            .map(|char| {
-                if char.is_ascii_alphanumeric() {
-                    char
-                } else {
-                    '-'
-                }
-            })
-            .collect()
     }
 
     /// Returns a string representing the environment name for use as a

--- a/src/os_util.rs
+++ b/src/os_util.rs
@@ -26,19 +26,6 @@ pub fn host_home_dir() -> &'static HostPath {
     &HOME_DIR
 }
 
-pub fn get_hostname() -> Option<String> {
-    #[cfg(unix)]
-    {
-        let uname = rustix::process::uname();
-        if let Ok(node_name) = uname.nodename().to_str() {
-            if !node_name.is_empty() {
-                return Some(node_name.to_owned());
-            }
-        }
-    }
-    None
-}
-
 pub struct Uids {
     pub real_user: u64,
     pub group: u64,
@@ -112,12 +99,6 @@ fn timezone_from_localtime_target(path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
-
-    #[test]
-    fn get_hostname() {
-        println!("Hostname: {:?}", super::get_hostname());
-        // Yay, didn't crash!
-    }
 
     #[test]
     fn timezone_from_localtime_target() {


### PR DESCRIPTION
Fix Issue #44: "docker fails with overly long hostnames"

I don't know if setting the hostname was useful or important anywhere other than the shell prompt. If so, it's easy to revert this.